### PR TITLE
Update version, contributors, and repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "furaffinity-api",
-  "version": "3.5.1",
+  "version": "3.5.1-lineaje-01",
   "description": "FurAffinity wrapper for Node.js",
   "main": "dist/index.js",
   "scripts": {
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/recallfuture/furaffinity-api"
+    "url": "https://github.com/lineaje-labs-gos/furaffinity-api"
   },
   "keywords": [
     "furaffinity"
@@ -18,7 +18,11 @@
   "contributors": [
     "mcrocks999",
     "recallfuture",
-    "radarcz"
+    "radarcz",
+    {
+      "name": "Lineaje DepFixer",
+      "email": "221268890+Lineaje-DepFixer@users.noreply.github.com"
+    }
   ],
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
- Appended '-lineaje-01' to the version.
- Updated repository URL to point to the new repourl in lineaje-labs-gos
